### PR TITLE
Fix Rails 7.1 no default serializer

### DIFF
--- a/lib/embedded_localization/active_record/act_macro.rb
+++ b/lib/embedded_localization/active_record/act_macro.rb
@@ -23,7 +23,7 @@ module EmbeddedLocalization
         # ::Rails::Railtie.subclasses.map(&:to_s).include?("ActiveRecord::Railtie")
         #+
 
-        serialize :i18n   # we should also protect it from direct assignment by the user
+        serialize :i18n, coder: YAML, type: Hash   # we should also protect it from direct assignment by the user
 
         #-
         # if Mongoid::Document is in the list of classes which extends the class we are included into:


### PR DESCRIPTION
Rails 7.1 introduce a breaking change by not using a default serializer.
[Source](https://github.com/rails/rails/blob/6b93fff8af32ef5e91f4ec3cfffb081d0553faf0/activerecord/CHANGELOG.md?plain=1#L995C5-L996C1) 

This means we have to provide a `:coder` attribute to the `serialize` method.

Fix #10 