### PR TITLE
🩹 Fix active support proxy object deprecation

### DIFF
--- a/embedded_localization.gemspec
+++ b/embedded_localization.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "https://github.com/tilo/embedded_localization/blob/main/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/tilo/embedded_localization/blob/master/CHANGELOG.md"
 
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/embedded_localization.rb
+++ b/lib/embedded_localization.rb
@@ -1,3 +1,4 @@
+require "active_record"
 require "embedded_localization/version"
 require 'extensions/hash'
 


### PR DESCRIPTION
Because of the following deprecation message:
> DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will
> be removed in Rails 8.0.
> Use Ruby's built-in BasicObject instead.

I've found that it comes from this gem:
```sh
❯ ruby -rbundler/setup -e "Bundler.require"
.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/embedded_localization-1.3.0/lib/embedded_localization.rb:9:in `<top (required)>': uninitialized constant ActiveRecord (NameError)
ActiveRecord::Base.extend(EmbeddedLocalization::ActiveRecord::ActMacro)
```

This PR fix the issue.